### PR TITLE
📝 Changed GitHub URL in plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -12,8 +12,8 @@
   "keywords": ["Modern", "Light", "Accessibility", "Minimalist"],
   "support": {
     "email": "code@whitespace.se",
-    "issues": "https://github.com/whitespace-se/matomo-dark-mode-theme/issues",
-    "source": "https://github.com/whitespace-se/matomo-dark-mode-theme"
+    "issues": "https://github.com/whitespace-se/matomo-modern-theme/issues",
+    "source": "https://github.com/whitespace-se/matomo-modern-theme"
   },
   "authors": [
     {


### PR DESCRIPTION
There are old links to this repository : 
```diff
"support": {
    "email": "code@whitespace.se",
-   "issues": "https://github.com/whitespace-se/matomo-dark-mode-theme/issues",
-   "source": "https://github.com/whitespace-se/matomo-dark-mode-theme"
  },
```

Replaced by

```diff
"support": {
    "email": "code@whitespace.se",
+   "issues": "https://github.com/whitespace-se/matomo-modern-theme/issues",
+   "source": "https://github.com/whitespace-se/matomo-modern-theme"
  },
```