### PR TITLE
Fixed colors for flags and graph

### DIFF
--- a/Modern.php
+++ b/Modern.php
@@ -87,9 +87,9 @@ class Modern extends Plugin
                 }";
             
             $mergedContent .= "
-                div.sparkline img,
-                table.dataTable td.label img {
+                div.sparkline img {
                     filter: invert(100%) hue-rotate(180deg);
+                    background-color: unset;
                 }
                 ";
         }


### PR DESCRIPTION
Avoid the filter `invert(100%) hue-rotate(180deg)` for `table.dataTable td.label img`  :

### Before in dark theme

![Before in dark theme](https://user-images.githubusercontent.com/14293805/213595593-da5207c8-fd18-44c5-a140-90ae076c4e4d.png)


### After

![After in dark theme](https://user-images.githubusercontent.com/14293805/213595281-d8f33fd7-5f2f-4d3d-8977-386f4221e885.png)

![After in white theme](https://user-images.githubusercontent.com/14293805/213595412-111a73e5-ccd7-4108-a9e9-879c3dcc78e1.png)
